### PR TITLE
Add client authentication middleware

### DIFF
--- a/src/Exception/Oauth2/AuthenticationException.php
+++ b/src/Exception/Oauth2/AuthenticationException.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Exception\Oauth2;
+
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class AuthenticationException extends Exception
+{
+    public const CODE_FAILED = 1000;
+    public const CODE_JSON_DECODE_FAILED = 1001;
+    public const CODE_MISSING_DATA_IN_RESPONSE = 1002;
+    public const CODE_UNABLE_TO_DETERMINE_EXPIRATION = 1003;
+    public const CODE_UNABLE_TO_ENCODE_PAYLOAD = 1004;
+
+    private ?ResponseInterface $response = null;
+
+    public static function failed(?string $errorSlug, ?Throwable $previous = null): self
+    {
+        if (!empty($errorSlug)) {
+            $errorSlug = ": $errorSlug";
+        } elseif (null !== $previous) {
+            $errorSlug = ': ' . $previous->getMessage();
+        }
+        return new self('Authentication failed' . $errorSlug, self::CODE_FAILED, $previous);
+    }
+
+    public static function unableToDecodeResponse(): self
+    {
+        return new self('Unable to decode response as json string', self::CODE_JSON_DECODE_FAILED);
+    }
+
+    /**
+     * @param string[] $missing
+     */
+    public static function missingDataInResponse(array $missing): self
+    {
+        return new self(
+            'The authentication response is missing one or more attributes: ' . implode(', ', $missing),
+            self::CODE_MISSING_DATA_IN_RESPONSE
+        );
+    }
+
+    public static function unableToDetermineExpiration(int $expiresIn): self
+    {
+        return new self(
+            'Unable to determine expiration date based on ' . $expiresIn . ' seconds',
+            self::CODE_UNABLE_TO_DETERMINE_EXPIRATION
+        );
+    }
+
+    public static function unableToEncodePayload(?string $jsonError): self
+    {
+        return new self(
+            'Unable to encode authentication payload to json. Error: ' . ($jsonError ?? 'unknown'),
+            self::CODE_UNABLE_TO_ENCODE_PAYLOAD
+        );
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function setResponse(?ResponseInterface $response): self
+    {
+        $this->response = $response;
+        return $this;
+    }
+}

--- a/src/Factory/Oauth2/CredentialFactory.php
+++ b/src/Factory/Oauth2/CredentialFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Factory\Oauth2;
+
+use DateInterval;
+use DateTime;
+use Dogado\JsonApi\Client\Exception\Oauth2\AuthenticationException;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+
+class CredentialFactory implements CredentialFactoryInterface
+{
+    /**
+     * @throws AuthenticationException
+     */
+    public function fromAuthorityResponse(ResponseInterface $response): OAuth2Credentials
+    {
+        list($tokenType, $accessToken, $expiresIn) = $this->parseResponse($response);
+
+        try {
+            $expiresAt = (new DateTime())->add(new DateInterval('PT' . ((int) $expiresIn - 5) . 'S'));
+        } catch (Exception $e) {
+            throw AuthenticationException::unableToDetermineExpiration((int) $expiresIn);
+        }
+
+        return new OAuth2Credentials($tokenType, $accessToken, $expiresAt);
+    }
+
+    /**
+     * @throws AuthenticationException
+     */
+    private function parseResponse(ResponseInterface $response): array
+    {
+        $responseBody = $response->getBody()->getContents();
+        $response->getBody()->rewind();
+        if (empty($responseBody)) {
+            throw AuthenticationException::unableToDecodeResponse()->setResponse($response);
+        }
+
+        $data = json_decode($responseBody, true);
+        if (empty($data) || !is_array($data)) {
+            throw AuthenticationException::unableToDecodeResponse()->setResponse($response);
+        }
+
+        $this->checkForErrors($data, $response);
+        return $this->parseData($data);
+    }
+
+    /**
+     * @throws AuthenticationException
+     */
+    private function checkForErrors(array $data, ResponseInterface $response): void
+    {
+        if (isset($data['error'])) {
+            $errorSlug = $data['error'];
+            throw AuthenticationException::failed($errorSlug)->setResponse($response);
+        }
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     * @throws AuthenticationException
+     */
+    private function parseData(array $data): array
+    {
+        $missing = [];
+        $tokenType = $data['token_type'] ?? null;
+        if (empty($tokenType)) {
+            $missing[] = 'token_type';
+        }
+        $accessToken = $data['access_token'] ?? null;
+        if (empty($accessToken)) {
+            $missing[] = 'access_token';
+        }
+        $expiresIn = $data['expires_in'] ?? null;
+        if (empty($expiresIn)) {
+            $missing[] = 'expires_in';
+        }
+
+        if (!empty($missing)) {
+            throw AuthenticationException::missingDataInResponse($missing);
+        }
+
+        return [
+            $tokenType,
+            $accessToken,
+            $expiresIn,
+        ];
+    }
+}

--- a/src/Factory/Oauth2/CredentialFactoryInterface.php
+++ b/src/Factory/Oauth2/CredentialFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Factory\Oauth2;
+
+use Dogado\JsonApi\Client\Exception\Oauth2\AuthenticationException;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Psr\Http\Message\ResponseInterface;
+
+interface CredentialFactoryInterface
+{
+    /**
+     * @throws AuthenticationException
+     */
+    public function fromAuthorityResponse(ResponseInterface $response): OAuth2Credentials;
+}

--- a/src/Middleware/AuthenticationMiddleware.php
+++ b/src/Middleware/AuthenticationMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Middleware;
+
+use Dogado\JsonApi\Client\Model\BasicCredentials;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Dogado\JsonApi\Model\Request\RequestInterface;
+
+class AuthenticationMiddleware implements AuthenticationMiddlewareInterface
+{
+    protected ?OAuth2Credentials $oauth2Credentials = null;
+    protected ?BasicCredentials $basicCredentials = null;
+
+    public function setOAuth2Credentials(OAuth2Credentials $oauth2Credentials): self
+    {
+        $this->oauth2Credentials = $oauth2Credentials;
+        return $this;
+    }
+
+    public function setBasicCredentials(BasicCredentials $basicCredentials): self
+    {
+        $this->basicCredentials = $basicCredentials;
+        return $this;
+    }
+
+    public function authenticateRequest(RequestInterface $request): void
+    {
+        if (null !== $this->oauth2Credentials) {
+            $request->headers()->merge([
+               'Authorization' => $this->oauth2Credentials->tokenType . ' ' . $this->oauth2Credentials->accessToken,
+            ]);
+        }
+
+        if (null !== $this->basicCredentials) {
+            $request->headers()->merge([
+               'Authorization' => 'Basic ' . base64_encode(
+                   $this->basicCredentials->username . ':' . $this->basicCredentials->password
+               ),
+            ]);
+        }
+    }
+}

--- a/src/Middleware/AuthenticationMiddlewareInterface.php
+++ b/src/Middleware/AuthenticationMiddlewareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Middleware;
+
+use Dogado\JsonApi\Model\Request\RequestInterface;
+
+interface AuthenticationMiddlewareInterface
+{
+    public function authenticateRequest(RequestInterface $request): void;
+}

--- a/src/Model/BasicCredentials.php
+++ b/src/Model/BasicCredentials.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Model;
+
+/**
+ * Credentials for the HTTP basic auth.
+ */
+class BasicCredentials
+{
+    public string $username;
+    public string $password;
+
+    public function __construct(string $username, string $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+}

--- a/src/Model/OAuth2Credentials.php
+++ b/src/Model/OAuth2Credentials.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Model;
+
+use DateTimeInterface;
+
+class OAuth2Credentials
+{
+    public string $tokenType;
+    public string $accessToken;
+    public ?DateTimeInterface $expiresAt;
+
+    public function __construct(string $tokenType, string $accessToken, DateTimeInterface $expiresAt = null)
+    {
+        $this->tokenType = $tokenType;
+        $this->accessToken = $accessToken;
+        $this->expiresAt = $expiresAt;
+    }
+
+    public function isExpired(): bool
+    {
+        return null !== $this->expiresAt && $this->expiresAt->getTimestamp() <= time();
+    }
+}

--- a/src/Service/OAuth2Authenticator.php
+++ b/src/Service/OAuth2Authenticator.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dogado\JsonApi\Client\Service;
+
+use Dogado\JsonApi\Client\Exception\Oauth2\AuthenticationException;
+use Dogado\JsonApi\Client\Factory\Oauth2\CredentialFactoryInterface;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UriInterface;
+use Throwable;
+
+class OAuth2Authenticator
+{
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected StreamFactoryInterface $streamFactory;
+    protected CredentialFactoryInterface $authStorageFactory;
+
+    public function __construct(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
+        CredentialFactoryInterface $authStorageFactory
+    ) {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
+        $this->authStorageFactory = $authStorageFactory;
+    }
+
+    /**
+     * @throws AuthenticationException
+     */
+    public function withClientCredentials(
+        UriInterface $endpointUri,
+        string $clientId,
+        string $clientSecret
+    ): OAuth2Credentials {
+        $payload = [
+            'grant_type' => 'client_credentials',
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+        ];
+
+        $payload = json_encode($payload);
+        if (false === $payload) {
+            throw AuthenticationException::unableToEncodePayload(json_last_error_msg());
+        }
+
+        try {
+            $request = $this->requestFactory
+                ->createRequest('POST', $endpointUri)
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->streamFactory->createStream($payload));
+
+            $response = $this->httpClient->sendRequest($request);
+        } catch (Throwable $e) {
+            throw AuthenticationException::failed(null, $e);
+        }
+
+        return $this->authStorageFactory->fromAuthorityResponse($response);
+    }
+}

--- a/tests/Factory/Oauth2/CredentialFactoryTest.php
+++ b/tests/Factory/Oauth2/CredentialFactoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Dogado\JsonApi\Client\Tests\Factory\Oauth2;
+
+use DateInterval;
+use DateTime;
+use Dogado\JsonApi\Client\Exception\Oauth2\AuthenticationException;
+use Dogado\JsonApi\Client\Factory\Oauth2\CredentialFactory;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Dogado\JsonApi\Client\Tests\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class CredentialFactoryTest extends TestCase
+{
+    public function testConversion(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $responseData = [
+            'token_type' => $this->faker()->slug,
+            'access_token' => $this->faker()->md5,
+            'expires_in' => $this->faker()->numberBetween(),
+        ];
+        $stream->method('getContents')->willReturn(json_encode($responseData));
+
+        $expiresAt = (new DateTime())->add(new DateInterval('PT' . ((int) $responseData['expires_in'] - 5) . 'S'));
+        $expected = new OAuth2Credentials($responseData['token_type'], $responseData['access_token'], $expiresAt);
+        $actual = (new CredentialFactory())->fromAuthorityResponse($response);
+
+        $this->assertInstanceOf(OAuth2Credentials::class, $actual);
+        $this->assertEquals($expected->tokenType, $actual->tokenType);
+        $this->assertEquals($expected->accessToken, $actual->accessToken);
+        $this->assertEquals($expected->expiresAt->getTimestamp(), $actual->expiresAt->getTimestamp());
+    }
+
+    public function testInvalidExpirationInterval(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $responseData = [
+            'token_type' => $this->faker()->slug,
+            'access_token' => $this->faker()->md5,
+            'expires_in' => -1 * $this->faker()->numberBetween(),
+        ];
+        $stream->method('getContents')->willReturn(json_encode($responseData));
+
+        $this->expectExceptionObject(AuthenticationException::unableToDetermineExpiration($responseData['expires_in']));
+        (new CredentialFactory())->fromAuthorityResponse($response);
+    }
+
+    public function testMissingResult(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $stream->method('getContents')->willReturn(json_encode(['']));
+
+        $missing = [
+            'token_type',
+            'access_token',
+            'expires_in',
+        ];
+        $this->expectExceptionObject(AuthenticationException::missingDataInResponse($missing));
+        (new CredentialFactory())->fromAuthorityResponse($response);
+    }
+
+    public function testEmptyResponse(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $stream->method('getContents')->willReturn(null);
+
+        $this->expectExceptionObject(AuthenticationException::unableToDecodeResponse()->setResponse($response));
+        (new CredentialFactory())->fromAuthorityResponse($response);
+    }
+
+    public function testInvalidJson(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $stream->method('getContents')->willReturn($this->faker()->text);
+
+        $this->expectExceptionObject(AuthenticationException::unableToDecodeResponse()->setResponse($response));
+        (new CredentialFactory())->fromAuthorityResponse($response);
+    }
+
+    public function testErrorResponse(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $errorSlug = $this->faker()->slug;
+        $stream->method('getContents')->willReturn(json_encode(['error' => $errorSlug]));
+
+        $this->expectExceptionObject(AuthenticationException::failed($errorSlug)->setResponse($response));
+        (new CredentialFactory())->fromAuthorityResponse($response);
+    }
+}

--- a/tests/Middleware/AuthenticationMiddlewareTest.php
+++ b/tests/Middleware/AuthenticationMiddlewareTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Dogado\JsonApi\Client\Tests\Middleware;
+
+use Dogado\JsonApi\Client\Middleware\AuthenticationMiddleware;
+use Dogado\JsonApi\Client\Model\BasicCredentials;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Dogado\JsonApi\Client\Tests\TestCase;
+use Dogado\JsonApi\Model\Request\RequestInterface;
+use Dogado\JsonApi\Support\Collection\CollectionInterface;
+use Dogado\JsonApi\Support\Collection\KeyValueCollectionInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AuthenticationMiddlewareTest extends TestCase
+{
+    private AuthenticationMiddleware $authMiddleware;
+
+    /** @var RequestInterface|MockObject */
+    private $request;
+    /** @var CollectionInterface|MockObject */
+    private $headers;
+
+    protected function setUp(): void
+    {
+        $this->authMiddleware = new AuthenticationMiddleware();
+        $this->request = $this->createMock(RequestInterface::class);
+        $this->headers = $this->createMock(KeyValueCollectionInterface::class);
+        $this->request->expects(self::atLeastOnce())->method('headers')->willReturn($this->headers);
+    }
+
+    public function testOAuth2(): void
+    {
+        $oauth2Credentials = new OAuth2Credentials(
+            $this->faker()->slug,
+            $this->faker()->md5,
+            $this->faker()->dateTime
+        );
+
+        $this->authMiddleware->setOAuth2Credentials($oauth2Credentials);
+        $this->headers->expects(self::once())->method('merge')->with([
+            'Authorization' => $oauth2Credentials->tokenType . ' ' . $oauth2Credentials->accessToken,
+        ]);
+
+        $this->authMiddleware->authenticateRequest($this->request);
+    }
+
+    public function testBasic(): void
+    {
+        $basicCredentials = new BasicCredentials(
+            $this->faker()->userName,
+            $this->faker()->password,
+        );
+
+        $this->authMiddleware->setBasicCredentials($basicCredentials);
+        $this->headers->expects(self::once())->method('merge')->with([
+            'Authorization' => 'Basic ' . base64_encode(
+                $basicCredentials->username . ':' . $basicCredentials->password
+            ),
+        ]);
+
+        $this->authMiddleware->authenticateRequest($this->request);
+    }
+}

--- a/tests/Model/Auth2CredentialsTest.php
+++ b/tests/Model/Auth2CredentialsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dogado\JsonApi\Client\Tests\Model;
+
+use DateTime;
+use DateTimeInterface;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Dogado\JsonApi\Client\Tests\TestCase;
+
+class Auth2CredentialsTest extends TestCase
+{
+    public function testIsExpired(): void
+    {
+        $inFuture = $this->createModel(
+            (new DateTime())->add(new \DateInterval('P' . $this->faker()->numberBetween(1, 10) . 'D'))
+        );
+        $this->assertFalse($inFuture->isExpired());
+
+        $inFuture = $this->createModel(
+            (new DateTime())->sub(new \DateInterval('PT' . $this->faker()->numberBetween(1, 10) . 'M'))
+        );
+        $this->assertTrue($inFuture->isExpired());
+
+        $notDefined = $this->createModel(null);
+        $this->assertFalse($notDefined->isExpired());
+    }
+
+    private function createModel(?DateTimeInterface $dateTime): OAuth2Credentials
+    {
+        return new OAuth2Credentials(
+            $this->faker()->slug,
+            $this->faker()->md5,
+            $dateTime
+        );
+    }
+}

--- a/tests/Model/BasicCredentialsTest.php
+++ b/tests/Model/BasicCredentialsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dogado\JsonApi\Client\Tests\Model;
+
+use Dogado\JsonApi\Client\Model\BasicCredentials;
+use Dogado\JsonApi\Client\Tests\TestCase;
+
+class BasicCredentialsTest extends TestCase
+{
+    public function test(): void
+    {
+        $username = $this->faker()->userName;
+        $password = $this->faker()->password;
+
+        $credentials = new BasicCredentials($username, $password);
+        $this->assertEquals($username, $credentials->username);
+        $this->assertEquals($password, $credentials->password);
+    }
+}

--- a/tests/Service/OAuth2AuthenticatorTest.php
+++ b/tests/Service/OAuth2AuthenticatorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Dogado\JsonApi\Client\Tests\Service;
+
+use Dogado\JsonApi\Client\Exception\Oauth2\AuthenticationException;
+use Dogado\JsonApi\Client\Factory\Oauth2\CredentialFactoryInterface;
+use Dogado\JsonApi\Client\Model\OAuth2Credentials;
+use Dogado\JsonApi\Client\Service\OAuth2Authenticator;
+use Dogado\JsonApi\Client\Tests\TestCase;
+use Exception;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class OAuth2AuthenticatorTest extends TestCase
+{
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected StreamFactoryInterface $streamFactory;
+    protected CredentialFactoryInterface $credentialFactory;
+    protected OAuth2Authenticator $authenticator;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $this->streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $this->credentialFactory = $this->createMock(CredentialFactoryInterface::class);
+        $this->authenticator = new OAuth2Authenticator(
+            $this->httpClient,
+            $this->requestFactory,
+            $this->streamFactory,
+            $this->credentialFactory
+        );
+    }
+
+    public function test(): void
+    {
+        $endpointUri = $this->createMock(UriInterface::class);
+        $clientId = $this->faker()->uuid;
+        $clientSecret = $this->faker()->password;
+
+        $payload = [
+            'grant_type' => 'client_credentials',
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+        ];
+
+        $request = $this->createMock(RequestInterface::class);
+        $this->requestFactory->expects(self::once())->method('createRequest')->with('POST', $endpointUri)
+            ->willReturn($request);
+        $request->expects(self::once())->method('withHeader')->with('Content-Type', 'application/json')
+            ->willReturnSelf();
+
+        $stream = $this->createMock(StreamInterface::class);
+        $this->streamFactory->expects(self::once())->method('createStream')->with(json_encode($payload))
+            ->willReturn($stream);
+
+        $request->expects(self::once())->method('withBody')->with($stream)->willReturnSelf();
+
+        $response = $this->createMock(ResponseInterface::class);
+        $this->httpClient->expects(self::once())->method('sendRequest')->with($request)->willReturn($response);
+
+        $authStorage = $this->createMock(OAuth2Credentials::class);
+        $this->credentialFactory->expects(self::once())->method('fromAuthorityResponse')->with($response)
+            ->willReturn($authStorage);
+
+        $this->assertEquals(
+            $authStorage,
+            $this->authenticator->withClientCredentials($endpointUri, $clientId, $clientSecret)
+        );
+    }
+
+    public function testInvalidPayload(): void
+    {
+        $endpointUri = $this->createMock(UriInterface::class);
+        $clientId = $this->faker()->uuid;
+        $clientSecret = utf8_decode('äöä');
+
+        json_encode($clientSecret);
+        $this->expectExceptionObject(AuthenticationException::unableToEncodePayload(json_last_error_msg()));
+        $this->authenticator->withClientCredentials($endpointUri, $clientId, $clientSecret);
+    }
+
+    public function testHttpError(): void
+    {
+        $endpointUri = $this->createMock(UriInterface::class);
+        $clientId = $this->faker()->uuid;
+        $clientSecret = $this->faker()->password;
+
+        $payload = [
+            'grant_type' => 'client_credentials',
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+        ];
+
+        $request = $this->createMock(RequestInterface::class);
+        $this->requestFactory->expects(self::once())->method('createRequest')->with('POST', $endpointUri)
+            ->willReturn($request);
+        $request->expects(self::once())->method('withHeader')->with('Content-Type', 'application/json')
+            ->willReturnSelf();
+
+        $stream = $this->createMock(StreamInterface::class);
+        $this->streamFactory->expects(self::once())->method('createStream')->with(json_encode($payload))
+            ->willReturn($stream);
+
+        $request->expects(self::once())->method('withBody')->with($stream)->willReturnSelf();
+
+        $e = $this->createMock(Exception::class);
+        $this->httpClient->expects(self::once())->method('sendRequest')->with($request)->willThrowException($e);
+
+        $this->expectExceptionObject(AuthenticationException::failed(null, $e));
+        $this->authenticator->withClientCredentials($endpointUri, $clientId, $clientSecret);
+    }
+}


### PR DESCRIPTION
This pull request adds an authentication middleware to support a standard set of authentication mechanisms which is also easily adaptable:
* OAuth2 client credentials
* HTTP basic auth