### PR TITLE
Remove `illuminate/support` as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0 - 2021-07-XX
+
+- remove `illuminate/support` as dependency
+
 ## v1.0.0 - 2021-05-25
 
 - initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.1.0 - 2021-07-XX
+## v1.0.1 - 2021-07-XX
 
 - remove `illuminate/support` as dependency
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "dogado/json-api-common": "^1.0",
-        "illuminate/support": "^7.0 || ^8.0",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0"
     },

--- a/src/Factory/RequestFactory.php
+++ b/src/Factory/RequestFactory.php
@@ -8,7 +8,6 @@ use Dogado\JsonApi\Exception\JsonApi\BadRequestException;
 use Dogado\JsonApi\Model\Document\DocumentInterface;
 use Dogado\JsonApi\Model\Request\Request;
 use Dogado\JsonApi\Model\Request\RequestInterface;
-use Illuminate\Support\Str;
 use Psr\Http\Message\UriInterface;
 
 class RequestFactory implements RequestFactoryInterface
@@ -102,7 +101,7 @@ class RequestFactory implements RequestFactoryInterface
         /* The prefix before any restful uri paths (e.g `v1`) */
         $apiBasePrefix = null;
         /* The prefix before the requested resource type (e.g `user/12345/`) */
-        $pathPrefix = trim(Str::before($path->getPath(), $resourceType), '/');
+        $pathPrefix = trim(strstr($path->getPath(), $resourceType, true) ?: $path->getPath(), '/');
         if ('' !== $uri->getPath()) {
             $apiBasePrefix = trim($uri->getPath(), '/');
             if (!empty($apiBasePrefix)) {


### PR DESCRIPTION
Just like in `dogado/json-api-common`, the `illuminate/support` package is rarely used and can be replaced by native php functions.