### PR TITLE
[2.0] require `dogado/json-api-common:^2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.0 - 2021-07-XX
+
+- require `dogado/json-api-common:^2.0`
+
+See [json-api-common changelog](https://github.com/dogado-group/json-api-common/blob/v2.0.0/CHANGELOG.md) for further details.
+
 ## v1.1.0 - 2021-07-10
 
 - drop support for php 7.4

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "dogado/json-api-common": "^1.0",
+        "dogado/json-api-common": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "fakerphp/faker": "^1.15",
-        "phpstan/phpstan": "^0.12.49",
+        "phpstan/phpstan": "^0.12.91",
         "http-interop/http-factory-guzzle": "^1.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since there is a `v2.0.0` release for the common package, we need to release the same major version for the client.